### PR TITLE
Improve markdown report formatting

### DIFF
--- a/src/techdebt_cli/scanner.py
+++ b/src/techdebt_cli/scanner.py
@@ -296,7 +296,8 @@ def scan_repo(repo_root: str, cfg: Config, since_days: int = 30, max_items: int 
                         )
                     )
 
-    # Cap and summarize
+    # Sort by score and cap
+    items.sort(key=lambda it: it.score, reverse=True)
     items = items[:max_items]
 
     json_items = []

--- a/src/techdebt_cli/templates/report.md.j2
+++ b/src/techdebt_cli/templates/report.md.j2
@@ -9,7 +9,7 @@
 | Path | Kind | Score | Notes |
 |------|------|-------|-------|
 {% for it in items[:10] -%}
-| `{{ it.path }}` | `{{ it.kind }}` | **{{ it.score }}** | {{ it.meta.snippet|default("") }} |
+| `{{ it.path }}` | `{{ it.kind }}` | **{{ '%.2f'|format(it.score) }}** | {{ (it.meta.snippet or it.meta.line or "")|replace('\n', ' ')|replace('|', '\\|')|truncate(80, True, '…') }} |
 {% endfor %}
 
 ## By Kind
@@ -22,16 +22,16 @@
 ## Quick Wins
 Small files (≤200 LOC) with high score (≥60). Good first refactors.
 {% for it in items if it.score >= 60 %}
-- **{{ it.score }}** — `{{ it.path }}` ({{ it.kind }})
+- **{{ '%.2f'|format(it.score) }}** — `{{ it.path }}` ({{ it.kind }})
 {% endfor %}
 
 ## Details
 {% for it in items %}
-### {{ it.path }} — {{ it.kind }} — **{{ it.score }}**
+### {{ it.path }} — {{ it.kind }} — **{{ '%.2f'|format(it.score) }}**
 - Owner: {{ it.owner or "n/a" }}
 - Bucket: {{ it.meta.priority_bucket }}
 - Evidence:
-  - {{ it.meta.snippet|default("") }}
+  - {{ (it.meta.snippet or it.meta.line or "")|replace('\n', ' ')|truncate(120, True, '…') }}
 - Components:
 {% for ck, cv in it.meta.components.items() %}
   - {{ ck }}: {{ "%.2f"|format(cv) }}

--- a/src/techdebt_cli/utils.py
+++ b/src/techdebt_cli/utils.py
@@ -44,7 +44,11 @@ def is_text_file(path: str) -> bool:
 
 def iter_files(repo_root: str, ignore: PathSpec, excludes: List[str]) -> Iterable[str]:
     exclude_spec = PathSpec.from_lines("gitwildmatch", excludes or [])
-    for root, _, files in os.walk(repo_root):
+    for root, dirs, files in os.walk(repo_root):
+        # Always skip the Git metadata directory
+        dirs[:] = [d for d in dirs if not d.startswith(".git")]
+        if os.path.relpath(root, repo_root).startswith(".git"):
+            continue
         for name in files:
             rel = os.path.relpath(os.path.join(root, name), repo_root)
             if ignore.match_file(rel) or exclude_spec.match_file(rel):


### PR DESCRIPTION
## Summary
- escape and truncate note snippets in Markdown report to avoid table formatting issues
- skip `.git` folder and order debt items by score for a cleaner report

## Testing
- `techdebt scan . --markdown`

------
https://chatgpt.com/codex/tasks/task_e_68a77fb0f294832da6de1c49b965bf63